### PR TITLE
Integrated additional unit test and package structure changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ coverage = "*"
 matplotlib = "~=3.7.1"
 numpy = "~=1.23.1"
 pandas = "~=1.5.3"
-pydantic = "~=1.8.2"
+pydantic = "^1.10.8"
 python-dotenv = "^0.5.1"
 pyyaml = "~=6.0"
 scikit-learn = "~=1.1.1"
@@ -36,6 +36,7 @@ pytest-cov = "*"
 flake8 = "*"
 mypy = "*"
 sphinx = "*"
+poetry = "*"
 
 [tool.flake8]
 max-line-length = 79

--- a/src/tests/test_abundance_bars.py
+++ b/src/tests/test_abundance_bars.py
@@ -1,0 +1,88 @@
+import os
+from unittest import TestCase
+
+import numpy as np
+
+import pandas as pd
+
+import matplotlib.pyplot as plt
+
+import warnings
+
+from omegaconf import DictConfig
+
+import visualization.abundance_bars as abundance_bars
+import helpers
+
+
+class TestAbundanceBars(TestCase):
+    def test_pile_up_abundance(self):
+        data = {
+            'beta-1': [0.0098, 0.0133, 0.1268],
+            'beta-2': [2.4536, 2.6672, 2.2194],
+            'ctrl-1': [0.0098, 0.6668, 0.2536],
+            'ctrl-2': [0.9814, 1.6003, 2.1560]
+        }
+        df = pd.DataFrame(data)
+        metadata_df = pd.DataFrame({
+            'name_to_plot': ['beta-1', 'beta-2', 'ctrl-1', 'ctrl-2'],
+            'condition': ['beta-glu', 'beta-glu', 'control', 'control'],
+            'timepoint': ['t0', 't0', 't0', 't0'],
+            'short_comp': ['ex', 'ex', 'ex', 'ex']
+        })
+        result = abundance_bars.pile_up_abundance(df, metadata_df)
+        self.assertTrue(result.shape == (12, 4))
+        self.assertListEqual(list(result.columns),
+                             ['timepoint', 'condition',
+                              'metabolite', 'abundance'])
+        self.assertTrue(any(
+            np.array(result['abundance']) == np.array(
+                [0.0098, 2.4536, 0.0098, 0.9814, 0.0133, 2.6672, 0.6668,
+                 1.6003, 0.1268, 2.2194, 0.2536, 2.156]
+            )))
+
+    def test_plot_one_metabolite(self):
+        warnings.filterwarnings("ignore")
+        df = pd.DataFrame({
+            'timepoint': ['t0', 't0'],
+            'condition': ['beta', 'alpha'],
+            'metabolite': ['m1', 'm1'],
+            'abundance' : [200, 700]
+        })
+        fig_this_metabolite, axs_k = plt.subplots(
+            nrows=1, ncols=1,
+            figsize=(5, 5))
+        result = abundance_bars.plot_one_metabolite(
+            df, "m1", axisx_var="timepoint",
+            hue_var="condition", axisx_labeltilt=30,
+            palette_choice="dark", curr_ax=axs_k)
+        bar = result.get_children()[0].get_facecolor()
+        # one of the bars color, rgba
+        self.assertAlmostEqual(bar[0], 0.062, 2)  # r
+        self.assertAlmostEqual(bar[1], 0.144, 2)  # g
+        self.assertAlmostEqual(bar[2],  0.435, 2)  # b
+
+    def test_plot_abundance_bars_no_grid(self):
+        warnings.filterwarnings("ignore")
+        df = pd.DataFrame({
+            'timepoint': ['t0', 't0'],
+            'condition': ['beta', 'alpha'],
+            'metabolite': ['m1', 'm1'],
+            'abundance' : [200, 700]
+        })
+        try:
+            os.makedirs("../__pycache__/")
+        except FileExistsError:
+            pass
+        cfg_m = DictConfig({'analysis': {'method': {'palette': 'dark'}}})
+        result = abundance_bars.plot_abundance_bars_no_grid(
+            df, ["m1"], "med", "total_abundance",
+            axisx_var="timepoint",
+            hue_var="condition",
+            output_directory="../__pycache__/",
+            axisx_labeltilt=30,
+            width_each_subfig=1.2,
+            height_each_subfig=2.4,
+            cfg=cfg_m)
+        self.assertTrue(result is None)
+

--- a/src/tests/test_distr_fit_plot.py
+++ b/src/tests/test_distr_fit_plot.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: Johanna Galvis, Florian Specque, Macha Nikolski
+"""
+
+from unittest import TestCase
+
+import helpers
+
+import numpy as np
+
+import pandas as pd
+
+import scipy.stats as stats
+
+import processing.fit_statistical_distribution as fit_statistical_distribution
+import visualization.distr_fit_plot as distr_fit_plot
+
+
+class TestDistrFitPlot(TestCase):
+    def test_make_pdf(self):
+        dist = getattr(stats, "gennorm")
+        params_dict =  {'beta': 1.09, 'loc': 0.01, 'scale': 1.77}
+        params = list(params_dict.values())
+        result = distr_fit_plot.make_pdf(dist, params, size=10000)
+        self.assertAlmostEqual(result.index[0],-5.9147, 2 )
+        self.assertAlmostEqual(result.index[-3], 5.932, 2 )
+        self.assertAlmostEqual(result.to_list()[1],  0.007, 3 )
+        self.assertAlmostEqual(result.to_list()[-1], 0.00699, 3)
+

--- a/src/tests/test_fit_statistical_distribution.py
+++ b/src/tests/test_fit_statistical_distribution.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: Johanna Galvis, Florian Specque, Macha Nikolski
+"""
+
+from unittest import TestCase
+
+import helpers
+
+import numpy as np
+
+import pandas as pd
+
+import scipy.stats._continuous_distns
+
+import processing.fit_statistical_distribution as fit_statistical_distribution
+
+
+class TestFitStatisticalDistribution(TestCase):
+    def test_compute_z_score(self):
+        data = {
+            "gmean_1" : [15, 6, 3.8, 18.6, 16, 12],
+            "gmean_2" : [1, 20, 16, 12, 2, 1.6],
+            "ratio": [15, 0.3, 0.23, 1.55, 8, 7.5],
+        }
+        df = pd.DataFrame(data)
+        result = fit_statistical_distribution.compute_z_score(df, "ratio")
+        self.assertTrue(any(np.array(result.loc[0, :]) == np.array(
+           [15.0, 1.0, 15.0, 1.793223]))
+        )
+        self.assertTrue(any(np.array(result.loc[1, :]) == np.array(
+           [6.0, 20.0, 0.30,  - 0.961258]))
+                        )
+        self.assertTrue(any(np.array(result.loc[2, :]) == np.array(
+           [3.8, 16.0, 0.23, -0.974374]))
+                        )
+        self.assertTrue(any(np.array(result.loc[3, :]) == np.array(
+           [18.6, 12.0, 1.55, -0.727033]))
+                        )
+
+    def test_find_best_distribution(self):
+        data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
+        df = pd.DataFrame(data)
+        best_distribution, args_param = \
+             fit_statistical_distribution.find_best_distribution(df)
+        #  unexpected distribution: 'gennorm' or dgamma or loglaplace or ?
+        #  impossible to set assert :
+        #  self.assertTrue(best_distribution.name == "laplace" |
+        #              best_distribution.name == "dgamma" )  #  can be false
+        self.assertIsInstance(best_distribution.name,
+                              str)
+        self.assertIsInstance(args_param, dict)
+        # self.assertIsInstance(best_distribution,
+        #                  scipy.stats._continuous_distns )  # failed
+
+    def test_best_fit(self):
+        data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
+        df = pd.DataFrame(data)
+        dist = np.around(np.array((df["zscore"]).astype(float)), 5)
+        best_dist, best_dist_name, best_fit_params = \
+            fit_statistical_distribution.get_best_fit(dist)
+        self.assertIsInstance(best_dist_name, str)
+        self.assertIsInstance(best_fit_params, str)
+
+
+
+
+
+
+
+
+

--- a/src/tests/test_isotopologue_proportions.py
+++ b/src/tests/test_isotopologue_proportions.py
@@ -1,0 +1,175 @@
+import os
+from unittest import TestCase
+
+import numpy as np
+
+import pandas as pd
+
+import matplotlib.pyplot as plt
+
+import warnings
+
+from omegaconf import DictConfig
+
+import visualization.isotopologue_proportions as isotopologue_proportions
+import helpers
+
+
+class TestIsotopologueProportionsPlot(TestCase):
+
+    def test_isotopologue_proportions_2piled_df(self):
+        data = {
+            'b-1': [0.2, 0.5, 0.3],
+            'b-2': [0.1, 0.7, 0.2],
+            'ctl-1': [0.6, 0.1, 0.3],
+            'ctl-2': [0.3, 0.2, 0.5]
+        }
+        df = pd.DataFrame(data)
+        df.index = ['cit_m+0', 'cit_m+1', 'cit_m+2']
+        metadata_df = pd.DataFrame({
+            'name_to_plot': ['b-1', 'b-2', 'ctl-1', 'ctl-2'],
+            'condition': ['b', 'b', 'ctl', 'ctl'],
+            'timepoint': ['t0', 't0', 't0', 't0'],
+            'timenum': [0, 0, 0, 0],
+            'short_comp': ['ex', 'ex', 'ex', 'ex'],
+            'original_name': ['', '', '', '']
+        })
+        result = isotopologue_proportions.isotopologue_proportions_2piled_df(
+            df, metadata_df
+        )
+        self.assertListEqual(
+            list(result.columns),
+            ["timenum", "condition", "isotopologue_name",
+             "Isotopologue Contribution (%)"]
+        )
+        self.assertTrue(any(np.array(result.loc[0, :]) == np.array(
+            ['0', 'b', 'cit_m+0', 20.0]
+        )))
+        self.assertTrue(any(np.array(result.loc[3, :]) == np.array(
+            ['0', 'ctl', 'cit_m+0', 30.0]
+        )))
+
+    def test_massage_isotopologues(self):
+        df = pd.DataFrame({
+            'timenum': ['0', '0', '0', '0', '0', '0',
+                        '0', '0', '0', '0', '0', '0'],
+            'condition': ['b', 'b', 'ctl', 'ctl', 'b', 'b',
+                          'ctl', 'ctl', 'b', 'b', 'ctl', 'ctl'],
+            'isotopologue_name': ['cit_m+0', 'cit_m+0', 'cit_m+0',
+                                  'cit_m+0', 'cit_m+1', 'cit_m+1',
+                                  'cit_m+1', 'cit_m+1', 'cit_m+2',
+                                  'cit_m+2', 'cit_m+2', 'cit_m+2'],
+            'Isotopologue Contribution (%)': [20, 10, 60, 30, 50, 70,
+                                              10, 20, 30, 20, 30, 50]
+        })
+        result = isotopologue_proportions.massage_isotopologues(
+            df
+        )
+        self.assertEqual(result.columns[-1], "m+x")
+        self.assertEqual(result.columns[-2], "metabolite")
+        self.assertEqual(result['metabolite'].unique().item(), "cit")
+
+    def test_prepare_means_replicates(self):
+        df = pd.DataFrame({
+            'timenum': ['0', '0', '0', '0', '0', '0',
+                        '0', '0', '0', '0', '0', '0'],
+            'condition': ['b', 'b', 'ctl', 'ctl', 'b', 'b',
+                          'ctl', 'ctl', 'b', 'b', 'ctl', 'ctl'],
+            'isotopologue_name': ['cit_m+0', 'cit_m+0', 'cit_m+0',
+                                  'cit_m+0', 'cit_m+1', 'cit_m+1',
+                                  'cit_m+1', 'cit_m+1', 'cit_m+2',
+                                  'cit_m+2', 'cit_m+2', 'cit_m+2'],
+            'Isotopologue Contribution (%)': [20, 10, 60, 30, 50, 70,
+                                              10, 20, 30, 20, 30, 50],
+            'metabolite': ['cit' for i in range(12)],
+            'm+x': ['m+0', 'm+0', 'm+0', 'm+0', 'm+1', 'm+1', 'm+1', 'm+1',
+                    'm+2', 'm+2', 'm+2', 'm+2']
+        })
+        result_dict = isotopologue_proportions.prepare_means_replicates(
+            df, metaboli_selected=['cit']
+        )
+        self.assertListEqual(list(result_dict.keys()), ['cit'])
+        self.assertEqual(result_dict['cit'].shape, (6, 5))
+        self.assertTrue(any(np.array(
+            result_dict['cit']['Isotopologue Contribution (%)']) == np.array(
+            [15.0, 60.0, 25.0, 45.0, 15.0, 40.0]
+        )))
+
+    def test_add_combined_conditime(self):
+        df = pd.DataFrame({
+            'timenum': ['0', '0', '0', '0', '0', '0'],
+            'condition': ['b', 'ctl', 'b',
+                          'ctl',  'b',  'ctl'],
+            'isotopologue_name': ['cit_m+0', 'cit_m+0',
+                                  'cit_m+1', 'cit_m+1',
+                                   'cit_m+2', 'cit_m+2'],
+            'Isotopologue Contribution (%)':   [15.0, 60.0, 25.0,
+                                                45.0, 15.0, 40.0],
+            'metabolite': ['cit' for i in range(6)],
+            'm+x': ['m+0', 'm+0',  'm+1', 'm+1',
+                    'm+2', 'm+2']})
+        dfs_dict = {'cit': df}
+        combined_tc_levels = ['0 : ctl', '0 : b', '0xemptyspace']
+        result = isotopologue_proportions.add_combined_conditime(
+            dfs_dict, combined_tc_levels)
+        self.assertListEqual(
+            result['cit']['time_and_condition'].tolist(),
+            ['0 : b', '0 : ctl', '0 : b', '0 : ctl', '0 : b', '0 : ctl']
+        )
+        self.assertEqual(
+            result['cit']['time_and_condition'].cat.categories[0],
+            '0 : ctl'
+        )
+        self.assertEqual(
+            result['cit']['time_and_condition'].cat.categories[1],
+            '0 : b'
+        )
+        self.assertEqual(
+            result['cit']['time_and_condition'].cat.categories[2],
+            '0xemptyspace'
+        )
+
+    def test_add_categorical_time(self):
+        df = pd.DataFrame({
+            'timenum': ['2','3','1','3','2','1'],
+            'condition': ['b', 'ctl', 'b',
+                          'ctl',  'b',  'ctl'],
+            'isotopologue_name': ['cit_m+0', 'cit_m+0',
+                                  'cit_m+1', 'cit_m+1',
+                                   'cit_m+2', 'cit_m+2'],
+            'Isotopologue Contribution (%)':   [15.0, 60.0, 25.0,
+                                                45.0, 15.0, 40.0],
+            'metabolite': ['cit' for i in range(6)],
+            'm+x': ['m+0', 'm+0',  'm+1', 'm+1',
+                    'm+2', 'm+2']})
+        dfs_dict = {'cit': df}
+        levels_time_str = ['1', '2', '3']
+        result = isotopologue_proportions.add_categorical_time(
+            dfs_dict, levels_time_str
+        )
+        self.assertEqual(
+            result['cit']['timenum'].cat.categories[0], '1')
+        self.assertEqual(result['cit']['timenum'].cat.categories[1], '2')
+        self.assertEqual(
+            result['cit']['timenum'].cat.categories[2], '3'
+        )
+
+    def test_give_colors_carbons(self):
+         result = isotopologue_proportions.
+
+    def test_add_xemptyspace_tolabs(self):
+        time_levels_list = [str(i) for i in sorted([1, 3, 2, 4])]
+        conditions = ['b', 'ctl']
+        result = isotopologue_proportions.add_xemptyspace_tolabs(
+            conditions, time_levels_list
+        )
+        self.assertListEqual(result[0], ['b', 'ctl', 'xemptyspace'])
+        self.assertListEqual(
+            result[1],
+            ['1 : b', '1 : ctl', '1xemptyspace',
+             '2 : b', '2 : ctl', '2xemptyspace',
+             '3 : b', '3 : ctl', '3xemptyspace',
+             '4 : b', '4 : ctl', '4xemptyspace'])
+
+
+

--- a/src/tests/test_pca_analysis.py
+++ b/src/tests/test_pca_analysis.py
@@ -86,3 +86,83 @@ class TestPcaAnalysis(TestCase):
         )
         self.assertListEqual(list(var_explained_df['PC']),
                              ["PC1", "PC2", "PC3"])
+
+    def test_pca_on_split_dataset(self):
+        data = {
+            'beta-1': [0.0098, 0.0133, 0.1268],
+            'beta-2': [2.4536, 2.6672, 2.2194],
+            'ctrl-1': [0.0098, 0.6668, 0.2536],
+            'ctrl-2': [0.9814, 1.6003, 2.1560]
+        }
+        df = pd.DataFrame(data)
+        metadata_df = pd.DataFrame({
+            'name_to_plot': ['beta-1', 'beta-2', 'ctrl-1', 'ctrl-2'],
+            'condition': ['beta-glu', 'beta-glu', 'control', 'control'],
+            'timepoint': ['t0', 't0', 't0', 't0'],
+            'short_comp': ['ex', 'ex', 'ex', 'ex']
+        })
+        description = ["my_file_name", "ex"]
+        result_dict = pca_analysis.pca_on_split_dataset(
+            df, metadata_df, chosen_column="condition",
+            description=description
+        )
+        self.assertEqual(list(result_dict.keys())[0],
+                         ('my_file_name', 'beta-glu', 'ex'))
+        self.assertEqual(list(result_dict.keys())[1],
+                         ('my_file_name', 'control', 'ex'))
+        result_pc_df = result_dict[('my_file_name', 'beta-glu', 'ex')]['pc']
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[0],
+                               -1.732, 3)
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[1],
+                               1.732, 3)
+        result_var_df = result_dict[('my_file_name', 'beta-glu', 'ex')]['var']
+        self.assertAlmostEqual(np.array(result_var_df[
+                                            'Explained Variance %'])[0],
+                               100.0, 1)
+        self.assertAlmostEqual(np.array(result_var_df[
+                                            'Explained Variance %'])[1],
+                               2.8e-31, 1)
+        result_pc_df2 = result_dict[('my_file_name', 'control', 'ex')]['pc']
+        self.assertAlmostEqual(np.array(result_pc_df2['PC2'])[1],
+                               1.24e-16, 2)
+        result_var_df2 = result_dict[('my_file_name', 'control', 'ex')]['var']
+        self.assertAlmostEqual(np.array(result_var_df2[
+                                            'Explained Variance %'])[1],
+                               5.18e-31, 2)
+
+    def test_pca_global_compartment_dataset(self):
+        data = {
+            'beta-1': [0.0098, 0.0133, 0.1268],
+            'beta-2': [2.4536, 2.6672, 2.2194],
+            'ctrl-1': [0.0098, 0.6668, 0.2536],
+            'ctrl-2': [0.9814, 1.6003, 2.1560]
+        }
+        df = pd.DataFrame(data)
+        metadata_df = pd.DataFrame({
+            'name_to_plot': ['beta-1', 'beta-2', 'ctrl-1', 'ctrl-2'],
+            'condition': ['beta-glu', 'beta-glu', 'control', 'control'],
+            'timepoint': ['t0', 't0', 't0', 't0'],
+            'short_comp': ['ex', 'ex', 'ex', 'ex']
+        })
+        description = ["my_file_name", "ex"]
+        result_dict = pca_analysis.pca_global_compartment_dataset(
+            df, metadata_df, description
+        )
+        self.assertEqual(list(result_dict.keys())[0],
+                         ('my_file_name', 'ex'))
+        result_pc_df = result_dict[('my_file_name', 'ex')]['pc']
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[0],
+                               -1.814, 3)
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[1],
+                               2.34, 2)
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[2],
+                               -1.358, 3)
+        self.assertAlmostEqual(np.array(result_pc_df['PC1'])[3],
+                               0.8, 1)
+        result_var_df = result_dict[('my_file_name', 'ex')]['var']
+        self.assertAlmostEqual(np.array(result_var_df[
+                                            'Explained Variance %'])[0],
+                               94.266, 3)
+        self.assertAlmostEqual(np.array(result_var_df[
+                                            'Explained Variance %'])[1],
+                               4.747, 3)

--- a/src/tests/test_pca_plot.py
+++ b/src/tests/test_pca_plot.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+import numpy as np
+
+import pandas as pd
+
+import visualization.pca_plot as pca_plot
+
+
+class TestPcaPlot(TestCase):
+
+    def test_eigsorted(self):
+        xdata = np.arange(-10, 10, 1)
+        ydata = np.arange(-1, 1, 0.1)
+        # get values to build the ellipse
+        cov = np.cov(xdata, ydata)
+        vals, vecs = pca_plot.eigsorted(cov)
+        self.assertAlmostEqual(vals[0], 3.535e+01, 2)
+        self.assertAlmostEqual(vals[1], 1.665e-16, 2)
+        self.assertAlmostEqual(vecs[0][0], -0.995, 2)
+        self.assertAlmostEqual(vecs[0][1],  0.099, 2)
+        self.assertAlmostEqual(vecs[1][0], -0.099, 2)
+        self.assertAlmostEqual(vecs[1][1], -0.995, 2)
+
+
+
+


### PR DESCRIPTION
I merged the changes from the package restructuring and the additional unit tests.

This also closes #6.

The tool can now be executed with `python3 -m dimet ...`.