### PR TITLE
disfit fixes & unitary tests improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DIMet: Differential analysis of Isotope-labeled targeted Metabolomics data
 DIMet is a bioinformatics pipeline for **differential and time-course analysis of targeted isotope-labeled metabolomics data**.
 
 DIMet supports the analysis of full metabolite abundances and isotopologue contributions, 
-and allows to perform it either in the differential comparison mode or as a time-series analysis. 
+and allows to perform it in the differential comparison mode, or as a time-series analysis, or even processing entire labelling profiles.
 As input, DIMet accepts three types of measures: a) isotopologues’ contributions, b) fractional contributions (also known as mean enrichment), c) full metabolites’ abundances. 
 DIMet also offers a _pathway-based omics integration_ through **Metabolograms**.
 

--- a/src/dimet/config/analysis/method/differential_analysis.yaml
+++ b/src/dimet/config/analysis/method/differential_analysis.yaml
@@ -21,3 +21,9 @@ statistical_test:
   mean_enrichment: KW
   isotopologues: KW
   isotopologue_proportions: KW
+
+disfit_tail_option: "auto"
+
+# Note: the disfit_tail_option depends on the comparison and the data:
+#    if advanced knowledge of both, set "two-sided" or "right-tailed"
+#    otherwise leave "auto" as default

--- a/src/dimet/config/analysis/method/metabologram_integration.yaml
+++ b/src/dimet/config/analysis/method/metabologram_integration.yaml
@@ -45,4 +45,10 @@ display_label_and_value : False # if False, display labels of the molecules alon
 
 color_nan_elements : "gray"
 
+disfit_tail_option: "two-sided"
+
+# Note: the disfit_tail_option depends on the comparison and the data:
+#    if advanced knowledge of both, set "two-sided" or "right-tailed"
+#    otherwise leave "auto" as default
+
 

--- a/src/dimet/config/analysis/method/time_course_analysis.yaml
+++ b/src/dimet/config/analysis/method/time_course_analysis.yaml
@@ -21,3 +21,9 @@ statistical_test:
   mean_enrichment: KW
   isotopologues: KW
   isotopologue_proportions: KW
+
+disfit_tail_option: "auto"
+
+# Note: the disfit_tail_option depends on the comparison and the data:
+#    if advanced knowledge of both, set "two-sided" or "right-tailed"
+#    otherwise leave "auto" as default

--- a/src/dimet/constants.py
+++ b/src/dimet/constants.py
@@ -49,10 +49,9 @@ correction_methods_type = Literal[
     "fdr_bh", "fdr_by", "fdr_tsbh", "fdr_tsbky"
 ]
 
-comparison_modes = ["pairwise", "multigroup"]  # TODO: verify if ever used
+# comparison_modes = ["pairwise", "multigroup"]  # unused to date
 
-comparison_modes_types = Literal[
-    "pairwise", "multigroup"]  # TODO: verify if ever used
+# comparison_modes_types = Literal["pairwise", "multigroup"]  # unused to date
 
 overlap_methods = ["symmetric", "asymmetric"]
 

--- a/src/dimet/helpers.py
+++ b/src/dimet/helpers.py
@@ -481,3 +481,11 @@ def message_bad_separator_input(df: pd.DataFrame, type_df: str) -> None:
             if df.empty:
                 logger.info(f"{e}. {error_message}")
                 raise ValueError(error_message)
+
+def msg_correction_method_not_suitable(filename: str, test:str) -> str:
+    message = (f"Using '{test}' for {filename}: the method"
+               f" for multiple tests correction (e.g. Bonferroni, "
+               f" B-H, or other), is unsuitable and will be omitted")
+    return message
+
+

--- a/src/dimet/helpers.py
+++ b/src/dimet/helpers.py
@@ -482,10 +482,9 @@ def message_bad_separator_input(df: pd.DataFrame, type_df: str) -> None:
                 logger.info(f"{e}. {error_message}")
                 raise ValueError(error_message)
 
-def msg_correction_method_not_suitable(filename: str, test:str) -> str:
+
+def msg_correction_method_not_suitable(filename: str, test: str) -> str:
     message = (f"Using '{test}' for {filename}: the method"
                f" for multiple tests correction (e.g. Bonferroni, "
                f" B-H, or other), is unsuitable and will be omitted")
     return message
-
-

--- a/src/dimet/method/__init__.py
+++ b/src/dimet/method/__init__.py
@@ -14,7 +14,7 @@ from dimet.constants import (assert_literal, availtest_methods,
                              data_types_suitable_for_metabologram,
                              metabolites_values_for_metabologram)
 from dimet.data import DataIntegration, Dataset
-from dimet.helpers import flatten
+from dimet.helpers import flatten, msg_correction_method_not_suitable
 from dimet.processing.bivariate_analysis import bivariate_comparison
 from dimet.processing.differential_analysis import (differential_comparison,
                                                     multi_group_compairson,
@@ -289,6 +289,8 @@ class DifferentialAnalysis(Method):
             tmp = dataset.get_file_for_label(file_name)  # current file name
             logger.info(
                 f"Running differential analysis of {tmp} using {test} test")
+            if test == "disfit":
+                logger.info(msg_correction_method_not_suitable(tmp, test))
             differential_comparison(file_name, dataset, cfg, test,
                                     out_table_dir=out_table_dir)
 
@@ -619,6 +621,8 @@ class TimeCourseAnalysis(Method):
             tmp = dataset.get_file_for_label(file_name)  # current file
             logger.info(
                 f"Running time-course analysis of {tmp} using {test} test")
+            if test == "disfit":
+                logger.info(msg_correction_method_not_suitable(tmp, test))
             time_course_analysis(file_name, dataset, cfg, test,
                                  out_table_dir=out_table_dir)
 

--- a/src/dimet/processing/differential_analysis.py
+++ b/src/dimet/processing/differential_analysis.py
@@ -248,7 +248,7 @@ def auto_detect_tailway(good_df, best_distribution, args_param):
 
 
 def run_distribution_fitting(df: pd.DataFrame,
-                             disfit_tail_option: str) ->  pd.DataFrame:
+                             disfit_tail_option: str) -> pd.DataFrame:
     recognized_tail_options = ["auto", "two-sided", "right-tailed"]
     assert disfit_tail_option in recognized_tail_options, ("unrecognized"
            "disfit_tail_option")
@@ -272,7 +272,7 @@ def run_distribution_fitting(df: pd.DataFrame,
     return df
 
 
-def reorder_columns_diff_end(df: pd.DataFrame, test:str) -> pd.DataFrame:
+def reorder_columns_diff_end(df: pd.DataFrame, test: str) -> pd.DataFrame:
     standard_cols = [
         "count_nan_samples_group1",
         "count_nan_samples_group2",
@@ -299,7 +299,7 @@ def reorder_columns_diff_end(df: pd.DataFrame, test:str) -> pd.DataFrame:
         "compartment"
     ]
 
-    if test == "disfit": # exclude the senseless column when this test ran
+    if test == "disfit":  # exclude the senseless column when this test ran
         standard_cols = [i for i in standard_cols if i != "padj"]
         desired_order = [i for i in desired_order if i != "padj"]
     standard_df = df[standard_cols]
@@ -331,8 +331,8 @@ def round_result_float_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 def compute_current_comparison_test(
         df_good: pd.DataFrame, df_bad: pd.DataFrame,
-        this_comparison: List[List], test:str, cfg: DictConfig
-) ->  pd.DataFrame:
+        this_comparison: List[List], test: str, cfg: DictConfig
+) -> pd.DataFrame:
     """
     Wraps functions for applying the parametric or non-parametric chosen test
     Note that 'this_comparison' is the list of, exactly,
@@ -366,6 +366,7 @@ def compute_current_comparison_test(
     result = round_result_float_columns(result)
 
     return result
+
 
 def pairwise_comparison(
         df: pd.DataFrame, dataset: Dataset, cfg: DictConfig,

--- a/src/dimet/processing/differential_analysis.py
+++ b/src/dimet/processing/differential_analysis.py
@@ -272,35 +272,33 @@ def compute_p_value(df: pd.DataFrame, test: str, best_dist,
     return df
 
 
-def filter_diff_results(ratiosdf, padj_cutoff, log2FC_abs_cutoff):
-    ratiosdf["abslfc"] = ratiosdf["log2FC"].abs()
-    ratiosdf = ratiosdf.loc[(ratiosdf["padj"] <= padj_cutoff) & (
-                ratiosdf["abslfc"] >= log2FC_abs_cutoff), :]
-    ratiosdf = ratiosdf.sort_values(["padj", "pvalue", "distance/span"],
-                                    ascending=[True, True, False])
-    ratiosdf = ratiosdf.drop(columns=["abslfc"])
+# def filter_diff_results(ratiosdf, padj_cutoff, log2FC_abs_cutoff): # TODO: delete as never used
+#     ratiosdf["abslfc"] = ratiosdf["log2FC"].abs()
+#     ratiosdf = ratiosdf.loc[(ratiosdf["padj"] <= padj_cutoff) & (
+#                 ratiosdf["abslfc"] >= log2FC_abs_cutoff), :]
+#     ratiosdf = ratiosdf.sort_values(["padj", "pvalue", "distance/span"],
+#                                     ascending=[True, True, False])
+#     ratiosdf = ratiosdf.drop(columns=["abslfc"])
+#
+#     return ratiosdf
 
-    return ratiosdf
 
-
-def reorder_columns_diff_end(df: pd.DataFrame) -> pd.DataFrame:
+def reorder_columns_diff_end(df: pd.DataFrame, test:str) -> pd.DataFrame:
     standard_cols = [
         "count_nan_samples_group1",
         "count_nan_samples_group2",
         "distance",
         "span_allsamples",
         "distance/span",
-        #        'stat',
         "pvalue",
         "padj",
         "log2FC",
         "FC",
-        "compartment",
+        "compartment"
     ]
 
     desired_order = [
         "log2FC",
-        #        'stat',
         "pvalue",
         "padj",
         "distance/span",
@@ -309,9 +307,12 @@ def reorder_columns_diff_end(df: pd.DataFrame) -> pd.DataFrame:
         "count_nan_samples_group2",
         "distance",
         "span_allsamples",
-        "compartment",
+        "compartment"
     ]
 
+    if test == "disfit": # exclude the senseless column when this test ran
+        standard_cols = [i for i in standard_cols if i != "padj"]
+        desired_order = [i for i in desired_order if i != "padj"]
     standard_df = df[standard_cols]
     df = df.drop(columns=standard_cols)
     # reorder the standard part
@@ -323,29 +324,56 @@ def reorder_columns_diff_end(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def round_result_float_columns(df: pd.DataFrame) -> pd.DataFrame:
-    result_float_columns = [
-        "log2FC",
-        "pvalue",
-        "padj",
-        "distance/span",
-        "FC",
-        "distance",
-        "span_allsamples"]
-
-    columns_gmean = [column for column in list(df.columns) if
-                     column.startswith("gmean_")]  # also gmean columns
-    result_float_columns = list(
-        set(result_float_columns).union(set(columns_gmean)))
-
-    for column in result_float_columns:
-        if column in list(df.columns):
+    for column in list(df.columns):
+        try:
             df[column] = np.around(
-                df[column].astype(float).to_numpy(),
-                decimals=6
-            )
-
+                 df[column].astype(float).to_numpy(),
+                 decimals=6
+             )
+        except ValueError:
+            continue
+        except TypeError:
+            continue
+        except Exception as e:
+            print(e)
+            continue
     return df
 
+
+def wrap_steps_test(df_good: pd.DataFrame, df_bad: pd.DataFrame,
+                    this_comparison: List[List], test:str,
+                    cfg: DictConfig) ->  pd.DataFrame: # TODO: rename
+    """
+    Wraps functions for applying the parametric or non-parametric chosen test
+    Note that 'this_comparison' is the list of, exactly, two lists
+    of samples names, e.g.:
+    [['Tr_cell_0h-1', 'Tr_cell_0h-2'], ['Ct_cell_0h-1', 'Ct_cell_0h-2']]
+    the first list corresponds to the treated samples,
+    the second list corresponds to the control samples.
+    """
+    # log transform, in base 2, the Fold Change
+    df_good = df_good.assign(log2FC=np.log2(df_good["FC"]))
+
+    if test == "disfit":
+        result = run_distribution_fitting(df_good)
+    else:
+        result_test_df = run_statistical_test(df_good, this_comparison, test)
+        assert result_test_df.shape[0] == df_good.shape[0]
+        result_test_df.set_index("metabolite", inplace=True)
+        df_good = pd.merge(df_good, result_test_df, left_index=True,
+                           right_index=True)
+        df_good, df_no_quality_d_s = split_rows_by_threshold(
+            df_good, "distance/span",
+            cfg.analysis.method.qualityDistanceOverSpan
+        )
+        df_good = compute_padj(df_good, 0.05,
+                               cfg.analysis.method.correction_method)
+        # re-integrate the "bad" sub-dataframes to the full dataframe
+        result = concatenate_dataframes(df_good, df_bad, df_no_quality_d_s)
+
+    result = round_result_float_columns(result)
+
+    return result
 
 def pairwise_comparison(
         df: pd.DataFrame, dataset: Dataset, cfg: DictConfig,
@@ -380,27 +408,9 @@ def pairwise_comparison(
     df_good, df_bad = select_rows_with_sufficient_non_nan_values(
         df4c, groups=this_comparison)
 
-    if test == "disfit":
-        df_good = run_distribution_fitting(df_good)
+    result = wrap_steps_test(df_good, df_bad,
+                                  this_comparison, test, cfg)
 
-    else:
-        result_test_df = run_statistical_test(df_good, this_comparison, test)
-        assert result_test_df.shape[0] == df_good.shape[0]
-        result_test_df.set_index("metabolite", inplace=True)
-        df_good = pd.merge(df_good, result_test_df, left_index=True,
-                           right_index=True)
-
-    df_good["log2FC"] = np.log2(df_good["FC"])
-
-    df_good, df_no_padj = split_rows_by_threshold(
-        df_good, "distance/span", cfg.analysis.method.qualityDistanceOverSpan
-    )
-    df_good = compute_padj(df_good, 0.05,
-                           cfg.analysis.method.correction_method)
-
-    # re-integrate the "bad" sub-dataframes to the full dataframe
-    result = concatenate_dataframes(df_good, df_bad, df_no_padj)
-    result = round_result_float_columns(result)
     return result
 
 
@@ -428,9 +438,9 @@ def differential_comparison(
         for comparison in cfg.analysis.comparisons:
             result = pairwise_comparison(df, dataset, cfg, comparison, test)
             result["compartment"] = compartment
-            result = reorder_columns_diff_end(result)
+            result = reorder_columns_diff_end(result, test)
 
-            result = result.sort_values(["padj", "distance/span"],
+            result = result.sort_values(["pvalue", "distance/span"],
                                         ascending=[True, False])
             comp = "-".join(map(lambda x: "-".join(x), comparison))
             base_file_name = dataset.get_file_for_label(file_name)
@@ -441,7 +451,7 @@ def differential_comparison(
                 output_file_name,
                 index_label="metabolite",
                 header=True,
-                sep="\t",
+                sep="\t"
             )
             logger.info(f"Saved the result in {output_file_name}")
 
@@ -550,8 +560,9 @@ def time_course_analysis(file_name: data_files_keys_type,
             result = pairwise_comparison(df, dataset, cfg, comparison,
                                          test)
             result["compartment"] = compartment
-            result = reorder_columns_diff_end(result)
-            result = result.sort_values(["padj", "distance/span"],
+            result = reorder_columns_diff_end(result, test)
+
+            result = result.sort_values(["pvalue", "distance/span"],
                                         ascending=[True, False])
             comp = "-".join(map(lambda x: "-".join(x), comparison))
             base_file_name = dataset.get_file_for_label(file_name)

--- a/src/dimet/processing/differential_analysis.py
+++ b/src/dimet/processing/differential_analysis.py
@@ -272,17 +272,6 @@ def compute_p_value(df: pd.DataFrame, test: str, best_dist,
     return df
 
 
-# def filter_diff_results(ratiosdf, padj_cutoff, log2FC_abs_cutoff): # TODO: delete as never used
-#     ratiosdf["abslfc"] = ratiosdf["log2FC"].abs()
-#     ratiosdf = ratiosdf.loc[(ratiosdf["padj"] <= padj_cutoff) & (
-#                 ratiosdf["abslfc"] >= log2FC_abs_cutoff), :]
-#     ratiosdf = ratiosdf.sort_values(["padj", "pvalue", "distance/span"],
-#                                     ascending=[True, True, False])
-#     ratiosdf = ratiosdf.drop(columns=["abslfc"])
-#
-#     return ratiosdf
-
-
 def reorder_columns_diff_end(df: pd.DataFrame, test:str) -> pd.DataFrame:
     standard_cols = [
         "count_nan_samples_group1",
@@ -340,13 +329,13 @@ def round_result_float_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def wrap_steps_test(df_good: pd.DataFrame, df_bad: pd.DataFrame,
-                    this_comparison: List[List], test:str,
-                    cfg: DictConfig) ->  pd.DataFrame: # TODO: rename
+def compute_current_comparison(df_good: pd.DataFrame, df_bad: pd.DataFrame,
+                               this_comparison: List[List], test:str,
+                               cfg: DictConfig) ->  pd.DataFrame: # TODO: rename
     """
     Wraps functions for applying the parametric or non-parametric chosen test
-    Note that 'this_comparison' is the list of, exactly, two lists
-    of samples names, e.g.:
+    Note that 'this_comparison' is the list of, exactly,
+    two lists of samples names, e.g.:
     [['Tr_cell_0h-1', 'Tr_cell_0h-2'], ['Ct_cell_0h-1', 'Ct_cell_0h-2']]
     the first list corresponds to the treated samples,
     the second list corresponds to the control samples.
@@ -408,8 +397,8 @@ def pairwise_comparison(
     df_good, df_bad = select_rows_with_sufficient_non_nan_values(
         df4c, groups=this_comparison)
 
-    result = wrap_steps_test(df_good, df_bad,
-                                  this_comparison, test, cfg)
+    result = compute_current_comparison(df_good, df_bad,
+                                        this_comparison, test, cfg)
 
     return result
 

--- a/src/dimet/processing/fit_statistical_distribution.py
+++ b/src/dimet/processing/fit_statistical_distribution.py
@@ -6,9 +6,11 @@
 import logging
 import warnings
 
+from typing import List, Union
 import numpy as np
 import pandas as pd
 import scipy.stats as stats
+
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +25,7 @@ def compute_z_score(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
     return df
 
 
-def find_best_distribution(df: pd.DataFrame):
+def find_best_distribution(df: pd.DataFrame, *args):
     """
     Find the best distribution among all the scipy.stats distributions
     and return it together with its parameters
@@ -33,8 +35,8 @@ def find_best_distribution(df: pd.DataFrame):
     """
     logger.info("Fitting a distribution")
     dist = np.around(np.array((df["zscore"]).astype(float)), 5)
-
-    best_dist, best_dist_name, best_fit_params = get_best_fit(dist)
+    # the optional *args are used by unitary tests
+    best_dist, best_dist_name, best_fit_params = get_best_fit(dist, *args)
 
     logger.info(f"Best fit is {best_dist_name} with {best_fit_params}")
     args_param = dict(e.split("=") for e in best_fit_params.split(", "))
@@ -47,14 +49,20 @@ def find_best_distribution(df: pd.DataFrame):
     return best_distribution, args_param
 
 
-def get_best_fit(input_array):
+def get_best_fit(input_array, *args):
     """Return the best fit distribution to data and its parameters"""
+
+    try: # *args are used by unitary tests
+        DISTRIBUTIONS = args[0]
+    except:
+        DISTRIBUTIONS = None
 
     # Load data
     data = pd.Series(input_array)
 
     # Find best fit distribution
-    best_fit_name, best_fit_params = best_fit_distribution(data, 200)
+    best_fit_name, best_fit_params = best_fit_distribution(
+        data, DISTRIBUTIONS,200)
 
     best_dist = getattr(stats, best_fit_name)
 
@@ -67,16 +75,8 @@ def get_best_fit(input_array):
     return best_dist, best_fit_name, param_str
 
 
-def best_fit_distribution(data, bins=200):
-    # TODO: try and catch exception and warnings
-    """Model data by finding best fit distribution to data"""
-    # Get histogram of original data
-    y, x = np.histogram(data, bins=bins, density=True)
-
-    x = (x + np.roll(x, -1))[:-1] / 2.0
-
-    # Distributions to check
-    # TODO: Get distribution list not hardcoded ?
+def get_distributions_list():
+    # Get distribution list not hardcoded was not possible to date.
     DISTRIBUTIONS = [
         stats.alpha,
         stats.anglit,
@@ -166,6 +166,22 @@ def best_fit_distribution(data, bins=200):
         stats.wrapcauchy,
     ]
 
+    return DISTRIBUTIONS
+
+
+def best_fit_distribution(
+        data: pd.DataFrame,
+        DISTRIBUTIONS: Union[List, None] = None,
+        bins: int = 200):
+    """Model data by finding best fit distribution to data"""
+    # Get histogram of original data
+    y, x = np.histogram(data, bins=bins, density=True)
+
+    x = (x + np.roll(x, -1))[:-1] / 2.0
+
+    if DISTRIBUTIONS is None:
+        DISTRIBUTIONS = get_distributions_list()
+
     # Best holders
     best_distribution = stats.norm
     best_params = (0.0, 1.0)
@@ -200,3 +216,17 @@ def best_fit_distribution(data, bins=200):
             pass
 
     return best_distribution.name, best_params
+
+
+def compute_p_value(df: pd.DataFrame, test: str, best_dist,
+                    args_param) -> pd.DataFrame:
+    """computes p-value on the results of the distribution fitting"""
+    if test == "right-tailed":
+        df["pvalue"] = 1 - best_dist.cdf(df["zscore"], **args_param)
+    elif test == "two-sided":
+        df["pvalue"] = 2 * (
+                    1 - best_dist.cdf(abs(df["zscore"]), **args_param))
+    else:
+        print("WARNING [compute_p_value]: only 'right-tailed' or " 
+              "'two-sided' as test argument supported")
+    return df

--- a/src/dimet/processing/fit_statistical_distribution.py
+++ b/src/dimet/processing/fit_statistical_distribution.py
@@ -52,9 +52,9 @@ def find_best_distribution(df: pd.DataFrame, *args):
 def get_best_fit(input_array, *args):
     """Return the best fit distribution to data and its parameters"""
 
-    try: # *args are used by unitary tests
+    try:  # *args are used by unitary tests
         DISTRIBUTIONS = args[0]
-    except:
+    except Exception:
         DISTRIBUTIONS = None
 
     # Load data
@@ -62,7 +62,7 @@ def get_best_fit(input_array, *args):
 
     # Find best fit distribution
     best_fit_name, best_fit_params = best_fit_distribution(
-        data, DISTRIBUTIONS,200)
+        data, DISTRIBUTIONS, 200)
 
     best_dist = getattr(stats, best_fit_name)
 
@@ -227,6 +227,6 @@ def compute_p_value(df: pd.DataFrame, test: str, best_dist,
         df["pvalue"] = 2 * (
                     1 - best_dist.cdf(abs(df["zscore"]), **args_param))
     else:
-        print("WARNING [compute_p_value]: only 'right-tailed' or " 
+        print("WARNING [compute_p_value]: only 'right-tailed' or "
               "'two-sided' as test argument supported")
     return df

--- a/src/dimet/visualization/distr_fit_plot.py
+++ b/src/dimet/visualization/distr_fit_plot.py
@@ -91,7 +91,7 @@ def get_best_fit_to_plot(input_array, out_file):
 
     # Find best fit distribution
     best_fit_name, best_fit_params = \
-        fit_statistical_distribution.best_fit_distribution(data, 200)
+        fit_statistical_distribution.best_fit_distribution(data, None, 200)
 
     best_dist = getattr(stats, best_fit_name)
 

--- a/src/dimet/visualization/metabologram.py
+++ b/src/dimet/visualization/metabologram.py
@@ -48,7 +48,6 @@ def get_differential_results_dict(file_name: str,
         result = differential_analysis.pairwise_comparison(
             df, data_integration, cfg, comparison, test)
         result["compartment"] = compartment
-        result = differential_analysis.reorder_columns_diff_end(result)
         result.reset_index(names=[cfg.analysis.columns_metabolites['ID']],
                            inplace=True)
         metabolomics_differential_results_dict[i] = result

--- a/tests/test_bivariate_analysis.py
+++ b/tests/test_bivariate_analysis.py
@@ -25,13 +25,13 @@ class TestBivariateAnalysis(TestCase):
                            'A-T0-1': [4.6, 4.6], 'A-T0-2': [6.5, 6.5],
                            'A-T1-1': [2, 2],
                            'A-T1-2': [10.1, 8.4], 'A-T4-1': [5.6, 3.6],
-                           'A-T4-1': [1.6, 1.8],
-                           'A-T7-1': [7.6, 7.6], 'A-T7-1': [8.1, 9.3],
+                           'A-T4-2': [1.6, 1.8],
+                           'A-T7-1': [7.6, 7.6], 'A-T7-2': [8.1, 9.3],
                            'B-T0-1': [8.1, 9.3], 'B-T0-2': [1.6, 1.8],
                            'B-T1-1': [6, 7],
                            'B-T1-2': [10.1, 8.4], 'B-T4-1': [3.2, 3.6],
-                           'B-T4-1': [6.5, 6.5],
-                           'B-T7-1': [4.6, 4.6], 'B-T7-1': [7.6, 7.6]})
+                           'B-T4-2': [6.5, 6.5],
+                           'B-T7-1': [4.6, 4.6], 'B-T7-2': [7.6, 7.6]})
         metadata_df = pd.DataFrame({
             'condition': ['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
                           'B', 'B', 'B', 'B', 'B', 'B', 'B', 'B'],
@@ -40,9 +40,9 @@ class TestBivariateAnalysis(TestCase):
             'timepoint': ['0h', '0h', '1.5h', '1.5h', '4h', '4h', '7h', '7h',
                           '0h', '0h', '1.5h', '1.5h', '4h', '4h', '7h', '7h'],
             'name_to_plot': ['A-T0-1', 'A-T0-2', 'A-T1-1', 'A-T1-2',
-                             'A-T4-1', 'A-T4-1', 'A-T7-1', 'A-T7-1',
+                             'A-T4-1', 'A-T4-2', 'A-T7-1', 'A-T7-2',
                              'B-T0-1', 'B-T0-2', 'B-T1-1', 'B-T1-2',
-                             'B-T4-1', 'B-T4-1', 'B-T7-1', 'B-T7-1']})
+                             'B-T4-1', 'B-T4-2', 'B-T7-1', 'B-T7-2']})
         comparison = ["A", "B"]
         result = bivariate_analysis.metabolite_time_profiles_gmean_df_dict(
             df, metadata_df, comparison
@@ -54,7 +54,7 @@ class TestBivariateAnalysis(TestCase):
         self.assertTrue(list(result.keys())[0] == 'metabo_time_profile')
         self.assertListEqual(
             result['metabo_time_profile'].iloc[0, 1].tolist(),
-            [5.468089, 4.494441, 1.6, 8.1])
+            [5.468089, 4.494441, 2.993326, 7.846018])
 
     def test_modify_gmean_by_sanity(self):
         df = pd.DataFrame({'A-T0-1': [4.6, np.nan],
@@ -139,6 +139,3 @@ class TestBivariateAnalysis(TestCase):
                                -0.992587, places=5)
         self.assertAlmostEqual(result.loc['Ala', 'pvalue'],
                                0.007413, places=5)
-
-
-

--- a/tests/test_differential_analysis.py
+++ b/tests/test_differential_analysis.py
@@ -96,16 +96,6 @@ class TestDifferentialAnalysis(TestCase):
         self.assertIsInstance(autoset_tailway, str)
         self.assertTrue(autoset_tailway in ["right-tailed", "two-sided"])
 
-    def test_filter_diff_results(self):
-        data = {'row': np.arange(0, 5, 1),
-                'pvalue': [0.004, 1.0, 0.064, 0.015, np.nan],
-                'padj': [0.004, 1.0, 0.064, 0.015, np.nan],
-                'log2FC': [4, 1.2, 0, -3, -1],
-                'distance/span': [1, -0.6, 0, 0.3, -0.6]}
-        df = pd.DataFrame(data)
-        result = differential_analysis.filter_diff_results(df, 0.05, 1.1)
-        self.assertTrue(result.shape[0] == 2)
-        self.assertTrue(any(np.array(result['row']) == np.array([0, 3])))
 
     def test_reorder_columns_diff_end(self):
         data = {

--- a/tests/test_differential_analysis.py
+++ b/tests/test_differential_analysis.py
@@ -108,7 +108,7 @@ class TestDifferentialAnalysis(TestCase):
         }
         df = pd.DataFrame(data)
         df.index = ['met1', 'met3']
-        result = differential_analysis.reorder_columns_diff_end(df)
+        result = differential_analysis.reorder_columns_diff_end(df, "BrMu")
         self.assertTrue(
             any(np.array(result.loc["met1", :]) == np.array(
                 [4.0, 1e-3, 1e-3, 0.5, 8, 0, 0, 2.0, 4, 'med', 400]

--- a/tests/test_differential_analysis.py
+++ b/tests/test_differential_analysis.py
@@ -96,7 +96,6 @@ class TestDifferentialAnalysis(TestCase):
         self.assertIsInstance(autoset_tailway, str)
         self.assertTrue(autoset_tailway in ["right-tailed", "two-sided"])
 
-
     def test_reorder_columns_diff_end(self):
         data = {
             "distance": [2, 1.5], "span_allsamples": [4, 6],

--- a/tests/test_fit_statistical_distribution.py
+++ b/tests/test_fit_statistical_distribution.py
@@ -8,8 +8,11 @@ from unittest import TestCase
 
 import numpy as np
 import pandas as pd
+from scipy import stats
 
 from dimet.processing import fit_statistical_distribution
+
+np.random.seed(123)
 
 
 class TestFitStatisticalDistribution(TestCase):
@@ -22,38 +25,72 @@ class TestFitStatisticalDistribution(TestCase):
         df = pd.DataFrame(data)
         result = fit_statistical_distribution.compute_z_score(df, "ratio")
         self.assertTrue(any(np.array(result.loc[0, :]) == np.array(
-           [15.0, 1.0, 15.0, 1.793223]))
-        )
+            [15.0, 1.0, 15.0, 1.793223]))
+                        )
         self.assertTrue(any(np.array(result.loc[1, :]) == np.array(
-           [6.0, 20.0, 0.30,  - 0.961258]))
+            [6.0, 20.0, 0.30, - 0.961258]))
                         )
         self.assertTrue(any(np.array(result.loc[2, :]) == np.array(
-           [3.8, 16.0, 0.23, -0.974374]))
+            [3.8, 16.0, 0.23, -0.974374]))
                         )
         self.assertTrue(any(np.array(result.loc[3, :]) == np.array(
-           [18.6, 12.0, 1.55, -0.727033]))
+            [18.6, 12.0, 1.55, -0.727033]))
                         )
+
+    def test_best_fit_distribution(self):
+        np.random.seed(123)
+        data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
+        df = pd.DataFrame(data)
+        MYDISTRIBUTIONS = [stats.laplace, stats.johnsonsu, stats.pareto]
+        name, params = fit_statistical_distribution.best_fit_distribution(
+            df, MYDISTRIBUTIONS, bins=200
+        )
+        self.assertIsInstance(name, str)
+        self.assertTrue(name in ['laplace', 'johnsonsu'])
+        self.assertAlmostEqual(params[0], -0.0257, places=3)
+        self.assertAlmostEqual(params[1], 1.03437, places=3)
+        self.assertAlmostEqual(params[2], -0.0834, places=3)
+        self.assertAlmostEqual(params[3], 1.5379, places=3)
+
+    def test_get_best_fit(self):
+        data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
+        df = pd.DataFrame(data)
+        dist = np.around(np.array((df["zscore"]).astype(float)), 5)
+        MYDISTRIBUTIONS = [stats.laplace, stats.norm,
+                           stats.johnsonsu, stats.pareto]
+        best_dist, best_dist_name, best_fit_params = \
+            fit_statistical_distribution.get_best_fit(dist,
+                                                      MYDISTRIBUTIONS)
+        self.assertTrue(best_dist_name in ['laplace', 'johnsonsu'])
+        self.assertIsInstance(best_fit_params, str)
 
     def test_find_best_distribution(self):
         data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
         df = pd.DataFrame(data)
-        best_distribution, args_param = (fit_statistical_distribution.
-                                         find_best_distribution(df))
-        #  unexpected distribution: 'gennorm' or dgamma or loglaplace or ?
-        #  impossible to set assert :
-        #  self.assertTrue(best_distribution.name == "laplace" |
-        #              best_distribution.name == "dgamma" )  #  can be false
-        self.assertIsInstance(best_distribution.name,
-                              str)
-        self.assertIsInstance(args_param, dict)
-        # self.assertIsInstance(best_distribution,
-        #                  scipy.stats._continuous_distns )  # failed
+        MYDISTRIBUTIONS = [stats.laplace, stats.norm,
+                           stats.johnsonsu, stats.pareto]
+        result, params = fit_statistical_distribution.find_best_distribution(
+            df, MYDISTRIBUTIONS
+        )
+        self.assertTrue(result.name in ['laplace', 'johnsonsu'])
+        self.assertIsInstance(params, dict)
+        self.assertListEqual(list(params.keys()), ['loc', 'scale'])
+        self.assertTrue(params['loc'] <= 0)
+        self.assertTrue(params['scale'] >= 1.6)
+        self.assertAlmostEqual(params['loc'], -0.03, places=1)
+        self.assertAlmostEqual(params['scale'], 1.85, places=1)
 
-    def test_best_fit(self):
+    def test_compute_p_value(self):
         data = {'zscore': np.random.laplace(loc=0.0, scale=1.6, size=500)}
         df = pd.DataFrame(data)
-        dist = np.around(np.array((df["zscore"]).astype(float)), 5)
-        best_dist, best_dist_name, best_fit_params = \
-            fit_statistical_distribution.get_best_fit(dist)
-        self.assertIsInstance(best_dist_name, str)
-        self.assertIsInstance(best_fit_params, str)
+
+        best_dist = stats.laplace
+        args_param = {'loc': -0.03, 'scale': 1.85}
+        result = fit_statistical_distribution.compute_p_value(
+            df, "right-tailed", best_dist, args_param
+        )
+        self.assertEqual(len(result['pvalue']), len(df["zscore"]) )
+        self.assertAlmostEqual(result['pvalue'][0], 0.7572, places=1)
+        self.assertAlmostEqual(result['pvalue'][1], 0.5879, places=1)
+        self.assertAlmostEqual(result['pvalue'][2], 0.1721, places=1)
+        self.assertAlmostEqual(result['pvalue'][4], 0.1721, places=1)

--- a/tests/test_fit_statistical_distribution.py
+++ b/tests/test_fit_statistical_distribution.py
@@ -89,7 +89,7 @@ class TestFitStatisticalDistribution(TestCase):
         result = fit_statistical_distribution.compute_p_value(
             df, "right-tailed", best_dist, args_param
         )
-        self.assertEqual(len(result['pvalue']), len(df["zscore"]) )
+        self.assertEqual(len(result['pvalue']), len(df["zscore"]))
         self.assertAlmostEqual(result['pvalue'][0], 0.7572, places=1)
         self.assertAlmostEqual(result['pvalue'][1], 0.5879, places=1)
         self.assertAlmostEqual(result['pvalue'][2], 0.1721, places=1)


### PR DESCRIPTION
- fixes the issue #25, as correction for multiple tests not suitable when distribution fitting test is applied.
- fixes the issue #12 and improves all  the unitary tests for  fit_statistical_distribution.py
- refactors functions of fit_statistical_distribution:  'find_best_distribution' accepts now (df, *args) where *args, a list of distributions' objects, is facultative ; the other functions adapted coherently. Aim: being able to select a smaller list of tests when running the unitary test, so now unitary tests run faster. 
- cleans code: unused function 'filter_diff_results' deleted  from tests and differential 
- moved 'compute_p_value' from differential to fit_statistical_distribution, as exclusively applies to it