### PR TITLE
Access test bivar

### DIFF
--- a/src/dimet/__main__.py
+++ b/src/dimet/__main__.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 @hydra.main(config_path="./config", config_name="config", version_base=None)
 def main_run_analysis(cfg: DictConfig) -> None:
     logger.info(f"The current working directory is {os.getcwd()}")
-    logger.info("Current configuration is %s", OmegaConf.to_yaml(cfg))
+    logger.info("Current configuration and defaults, %s",
+                OmegaConf.to_yaml(cfg))
 
     dataset: Dataset = Dataset(
         config=hydra.utils.instantiate(cfg.analysis.dataset))

--- a/src/dimet/config/analysis/method/bivariate_analysis.yaml
+++ b/src/dimet/config/analysis/method/bivariate_analysis.yaml
@@ -6,16 +6,16 @@ name: Computation of the correlation of MDV profiles, or the metabolite time cou
 # (**) : automatically will run
 
 conditions_MDV_comparison: # (**) if >= 2 conditions and >=1 timepoint (timepoints run separately)
-  isotopologue_proportions: pearson
+  isotopologue_proportions: spearman
 
 timepoints_MDV_comparison:  # (**) if >= 1 condition and >=2 timepoints
-  isotopologue_proportions: pearson
+  isotopologue_proportions: spearman
 
 conditions_metabolite_time_profiles:  # (**) if >= 2 conditions  AND >=2 time points in data
-  abundances: pearson
-  mean_enrichment: pearson
+  abundances: spearman
+  mean_enrichment: spearman
 
-# test modification doable with external config 'statistical_test'
+# test modification accessible through external config 'statistical_test'
 
 correction_method: fdr_bh
 

--- a/src/dimet/config/analysis/method/bivariate_analysis.yaml
+++ b/src/dimet/config/analysis/method/bivariate_analysis.yaml
@@ -15,6 +15,8 @@ conditions_metabolite_time_profiles:  # (**) if >= 2 conditions  AND >=2 time po
   abundances: pearson
   mean_enrichment: pearson
 
+# test modification doable with external config 'statistical_test'
+
 correction_method: fdr_bh
 
 impute_values:

--- a/src/dimet/config/analysis/method/differential_analysis.yaml
+++ b/src/dimet/config/analysis/method/differential_analysis.yaml
@@ -27,3 +27,5 @@ disfit_tail_option: "auto"
 # Note: the disfit_tail_option depends on the comparison and the data:
 #    if advanced knowledge of both, set "two-sided" or "right-tailed"
 #    otherwise leave "auto" as default
+
+# Note2: the statistical_test options can be modified using the external config (not here)

--- a/src/dimet/config/analysis/method/time_course_analysis.yaml
+++ b/src/dimet/config/analysis/method/time_course_analysis.yaml
@@ -27,3 +27,5 @@ disfit_tail_option: "auto"
 # Note: the disfit_tail_option depends on the comparison and the data:
 #    if advanced knowledge of both, set "two-sided" or "right-tailed"
 #    otherwise leave "auto" as default
+
+# Note2: the statistical_test options can be modified using the external config (not here)

--- a/src/dimet/constants.py
+++ b/src/dimet/constants.py
@@ -66,3 +66,6 @@ molecular_types_for_metabologram = ["transcripts", "metabolites"]
 columns_transcripts_config_keys = ['ID', 'values']
 
 metabolites_values_for_metabologram = ['log2FC', 'FC']
+
+# minimum non-zero value tolerated when values are fractions or proportions
+minimum_tolerated_fraction_value = 1e-4

--- a/src/dimet/constants.py
+++ b/src/dimet/constants.py
@@ -25,6 +25,8 @@ data_files_keys_type = Literal[
     "isotopologues",
 ]
 
+supported_file_extension = ["csv", "tsv"]
+
 availtest_methods = ["MW", "KW", "ranksum", "Wcox", "Tt", "BrMu", "prm-scipy",
                      "disfit", "none"]
 

--- a/src/dimet/helpers.py
+++ b/src/dimet/helpers.py
@@ -10,6 +10,7 @@ from functools import reduce
 from typing import Dict, List
 
 from dimet.constants import (assert_literal,
+                             minimum_tolerated_fraction_value,
                              overlap_methods_types,
                              supported_file_extension)
 
@@ -200,7 +201,9 @@ def arg_repl_zero2value(how: str, df: pd.DataFrame) -> float:
             except Exception as e:
                 logger.info(f"{e}. {err_msg}")
                 raise ValueError(err_msg)
-        min_value = df[df > 0].min(skipna=True).min(skipna=True)
+        min_value = df[
+            df >= minimum_tolerated_fraction_value  # '> 0' prone to errors if values < 1e-6 exist in the data (and round is 6 places!)
+        ].min(skipna=True).min(skipna=True)
         output_value = min_value / denominator
     else:
         try:

--- a/src/dimet/helpers.py
+++ b/src/dimet/helpers.py
@@ -3,12 +3,15 @@
 """
 @author: Johanna Galvis, Florian Specque, Macha Nikolski
 """
+import os
 import logging
 from collections.abc import Iterable
 from functools import reduce
 from typing import Dict, List
 
-from dimet.constants import assert_literal, overlap_methods_types
+from dimet.constants import (assert_literal,
+                             overlap_methods_types,
+                             supported_file_extension)
 
 import numpy as np
 
@@ -73,7 +76,7 @@ def concatenate_dataframes(df1: pd.DataFrame, df2: pd.DataFrame,
     df2 = df2.reindex(columns=df1.columns, fill_value=np.nan)
     df3 = df3.reindex(columns=df1.columns, fill_value=np.nan)
     # please leave ignore_index as False:
-    # otherwise numbers and not metabolites appear in .csv exported results:
+    # otherwise numbers and not metabolites appear in exported results:
     result = pd.concat([df1, df2, df3], ignore_index=False)
     return result
 
@@ -488,3 +491,18 @@ def msg_correction_method_not_suitable(filename: str, test: str) -> str:
                f" for multiple tests correction (e.g. Bonferroni, "
                f" B-H, or other), is unsuitable and will be omitted")
     return message
+
+
+def extfind(parent_folder_absolute, file_name):
+    repertoire_extension = supported_file_extension
+    out_str = ""
+    for x in repertoire_extension:
+        if not os.path.exists(
+                os.path.join(parent_folder_absolute,
+                             file_name + f".{x}")):
+            continue
+        else:
+            out_str = x
+    if out_str not in repertoire_extension:
+        out_str = "csv"  # if none of the supported extensions, try this one
+    return out_str

--- a/src/dimet/method/__init__.py
+++ b/src/dimet/method/__init__.py
@@ -1,7 +1,7 @@
 ﻿import logging
 import os
 import sys
-from typing import Union
+from typing import Dict, Union
 
 import hydra
 from omegaconf import DictConfig, ListConfig, OmegaConf, open_dict
@@ -191,6 +191,14 @@ class BivariateAnalysisConfig(MethodConfig):
     """
     correction_method: str = "fdr_bh"
     output_include_gmean_arr_columns: bool = True
+    conditions_MDV_comparison: Dict[str, str] = {
+        'isotopologue_proportions': 'spearman'}
+    timepoints_MDV_comparison: Dict[str, str] = {
+        'isotopologue_proportions': 'spearman'}
+    conditions_metabolite_time_profiles: Dict[str, str] = {
+        'abundances': 'spearman',
+        'mean_enrichment': 'spearman'
+    }
 
     def build(self) -> "BivariateAnalysis":
         return BivariateAnalysis(config=self)

--- a/src/dimet/processing/bivariate_analysis.py
+++ b/src/dimet/processing/bivariate_analysis.py
@@ -32,7 +32,7 @@ def compute_statistical_correlation(df: pd.DataFrame,
     stat_list = []
     pvalue_list = []
     for i, metabolite in enumerate(list(df['metabolite'])):
-        # array of n-(timepoints or m+x) geometrical means values
+        # array of n (timepoints or m+x) geometrical means values
         array_1 = df.loc[metabolite, "gmean_arr_1"]
         array_2 = df.loc[metabolite, "gmean_arr_2"]
         if test == "pearson":
@@ -79,7 +79,7 @@ def compute_bivariate_by_behavior(
     """
     performs two steps:
     1. calls functions to compute geometric means, obtaining df's inside dict
-    2. computes the bivariate statistical test (pearson by default)
+    2. computes the bivariate statistical test
     """
     if behavior == "conditions_MDV_comparison":
         df_dict = conditions_MDV_gmean_df_dict(df, metadata_df, comparison)

--- a/src/dimet/processing/pca_analysis.py
+++ b/src/dimet/processing/pca_analysis.py
@@ -121,12 +121,12 @@ def pca_global_compartment_dataset(df: pd.DataFrame,
 
 def send_to_tables(pca_results_compartment_dict: dict,
                    out_table_dir: str) -> None:
-    """ Save each result to .csv files """
+    """ Save each result to tab delimited files """
     for tup in pca_results_compartment_dict.keys():
         out_table = "--".join(list(tup))
         for df in pca_results_compartment_dict[tup].keys():
             pca_results_compartment_dict[tup][df].to_csv(
-                os.path.join(out_table_dir, f"{out_table}_{df}.csv"),
+                os.path.join(out_table_dir, f"{out_table}_{df}.tsv"),
                 sep='\t', index=False)
     logger.info(f"Saved pca tables in {out_table_dir}")
 
@@ -136,7 +136,7 @@ def run_pca_analysis(file_name: data_files_keys_type,
                      out_table_dir: str, mode: str) -> Union[None, dict]:
     """
     Generates all PCA results, both global (default) and with splited data.
-     - mode='save_tables', the PCA tables are saved to .csv;
+     - mode='save_tables', the PCA tables are saved to tab delimited files;
      or
      - mode='return_results_dict', returns the results object (dict)
     """

--- a/src/dimet/visualization/abundance_bars.py
+++ b/src/dimet/visualization/abundance_bars.py
@@ -62,8 +62,9 @@ def plot_one_metabolite(df: pd.DataFrame,
         palette=palette_choice,
         alpha=1,
         edgecolor="black",
-        errcolor="black",
-        errwidth=1.7,
+        # errcolor="black",   # deprecated in seaborn0.13.2
+        # errwidth=1.7,   # deprecated in seaborn0.13.2
+        err_kws={'linewidth': 1.7, 'color': 'black'},
         capsize=0.12,
     )
     if do_stripplot:

--- a/src/dimet/visualization/mean_enrichment_line_plot.py
+++ b/src/dimet/visualization/mean_enrichment_line_plot.py
@@ -338,7 +338,7 @@ def give_colors_by_metabolite(cfg: DictConfig,
                     colors_dict[metabolite] = "dimgray"
                 except Exception as e:
                     colors_dict[metabolite] = "dimgray"
-                    logger.info(e, "user color not readable, continuing")
+                    logger.info(e, "user color not readable, continue")
 
         except Exception as e:
             logger.info(e, f"\n could not assign color : \


### PR DESCRIPTION
- **bivariate analysis**: improves access from external config to allow the user to choose the correlation test: spearman or pearson
- for inputs, detects csv or tsv extension (both tab delimited files) , automatically
- minimum tolerated fraction value set as constant: this prevents any value < 1e-6, if present in the data, be taken to impute zeroes, causing zero division error as rounding is on 6 places
- fixes deprecated seaborn error bar options